### PR TITLE
Fix the shebang line

### DIFF
--- a/print.py
+++ b/print.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import argparse
 import asyncio
 import logging


### PR DESCRIPTION
Currently the shebang line in `print.py` is set
to `#!/usr/bin/env python`, which may not be compatible with Python 3.

It's updated to `#!/usr/bin/env python3`.